### PR TITLE
Use -r option of pip to specify requirements.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Recent advances in single-cell RNA sequencing technology provided unprecedented 
 The python packages needed for the analysis are in the requirement.txt file. They can be installed by executing:
 
 ```
-cat requirements.txt | xargs -n 1 pip install
+pip install -r requirements.txt
 ```
 
 ### Original Paper


### PR DESCRIPTION
Just a small suggestion for making the installation more straight-forward.